### PR TITLE
remove php from required packages installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Install and configure Composer
 ## :warning: Requirements
 
 Ansible >= 2.10
+PHP
 
 ## :zap: Installation
 

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -14,11 +14,11 @@ ENV {{ var }} {{ value }}
 {% endfor %}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 systemd wget && apt-get clean; \
-    elif [ $(command -v yum) ]; then yum install -y python3 sudo bash iproute systemd initscripts wget; \
-    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 wget && zypper clean -a; \
-    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates wget; \
-    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 wget && xbps-remove -O; fi
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 systemd wget php php-json && apt-get clean; \
+    elif [ $(command -v yum) ]; then yum install -y python3 sudo bash iproute systemd initscripts wget php php-json; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 wget php php-json && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates wget php php-json; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 wget php php-json && xbps-remove -O; fi
 
 RUN wget -O /usr/bin/systemctl https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py && \
     chmod +x /usr/bin/systemctl

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,8 +6,6 @@
       - curl
       - git
       - unzip
-      - php
-      - php-json
     state: present
 
 - name: Download composer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Supprime php des paquets installé par le rôle.

## Motivation and Context
PHP a besoin d'un rôle pour lui-même et ne devrait pas être installé par un autre rôle.
De plus, lors de l'utilisation du dépôt sury sur debian, l'installation du paquet "php" installe la dernière version de php. Cela n'est pas un comportement souhaitable.

## How Has This Been Tested?
Testé sur infra client en préprod, sur debian.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
